### PR TITLE
Compare the final return code against valid_return_codes

### DIFF
--- a/schwab_api/schwab.py
+++ b/schwab_api/schwab.py
@@ -255,7 +255,7 @@ class Schwab(SessionManager):
             for message in response["orderStrategy"]["orderMessages"]:
                 messages.append(message["message"])
 
-        if response["orderStrategy"]["orderReturnCode"] == 0:
+        if response["orderStrategy"]["orderReturnCode"] in valid_return_codes:
             return messages, True
         
         return messages, False


### PR DESCRIPTION
valid_return_codes is currently only used in a dry run request, which causes the real trade request to fail if the return code is not 0.