### PR TITLE
add old API compatibility for login() to solve get_account_info() return 1 account issue

### DIFF
--- a/example/example_legacy_v1.py
+++ b/example/example_legacy_v1.py
@@ -1,0 +1,48 @@
+from schwab_api import Schwab
+import pprint
+
+# Change these variables
+username = "username"
+password = "password"
+totp_secret = "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEF"
+
+# Initialize our schwab instance
+api = Schwab()
+
+# Login using playwright
+print("Logging into Schwab")
+logged_in = api.login(
+    username=username,
+    password=password,
+    totp_secret=totp_secret, # Get this using itsjafer.com/#/schwab.
+    version='v1'   # or use 'old' 
+)
+
+## Get information about a few tickers # legacy old API doesn't support quote
+#quotes = api.quote_v2(["PFE", "AAPL"])
+#pprint.pprint(quotes)
+
+# Get information about your accounts holdings
+print("Getting account holdings information")
+account_info = api.get_account_info()
+pprint.pprint(account_info)
+print("The following account numbers were found: " + str(account_info.keys()))
+
+print("Placing a dry run trade for PFE stock")
+# Place a dry run trade for each account
+messages, success = api.trade(
+    ticker="PFE", 
+    side="Buy", #or Sell
+    qty=1, 
+    account_id=next(iter(account_info)), # Replace with your account number
+    dry_run=True # If dry_run=True, we won't place the order, we'll just verify it.
+)
+
+print("The order verification was " + "successful" if success else "unsuccessful")
+print("The order verification produced the following messages: ")
+pprint.pprint(messages)
+
+#order is not supported in legacy old API
+#orders = api.orders_v2()
+#
+#pprint.pprint(orders)

--- a/schwab_api/authentication.py
+++ b/schwab_api/authentication.py
@@ -73,7 +73,7 @@ class SessionManager:
             self.headers = route.request.all_headers()
             route.continue_()
     
-    def login(self, username, password, totp_secret=None):
+    def login(self, username, password, totp_secret=None, version='v2'):
         """ This function will log the user into schwab using Playwright and saving
         the authentication cookies in the session header. 
         :type username: str
@@ -86,6 +86,9 @@ class SessionManager:
         :param totp_secret: The TOTP secret used to complete multi-factor authentication 
             through Symantec VIP. If this isn't given, sign in will use SMS.
 
+        :type version: Optional[str]
+        :param version: backward compatible with legacy/old API with 'v1' or 'old'
+
         :rtype: boolean
         :returns: True if login was successful and no further action is needed or False
             if login requires additional steps (i.e. SMS)
@@ -95,16 +98,24 @@ class SessionManager:
         with self.page.expect_navigation():
             self.page.goto("https://www.schwab.com/")
 
-
-        # Capture authorization token.
-        self.page.route(re.compile(r".*balancespositions*"), self.captureAuthToken)
+        if ('v2' in version):
+            # Capture authorization token.
+            self.page.route(re.compile(r".*balancespositions*"), self.captureAuthToken)
 
         # Wait for the login frame to load
         login_frame = "schwablmslogin"
         self.page.wait_for_selector("#" + login_frame)
-
-        self.page.frame(name=login_frame).select_option("select#landingPageOptions", index=3)
-
+        
+        if 'v1' in version or 'old' in version:
+            self.page.frame(name=login_frame).select_option("select#landingPageOptions", index=0)   #Account Summary
+            NextPageUrls=urls.account_summary()
+        elif 'v2' in version:
+            self.page.frame(name=login_frame).select_option("select#landingPageOptions", index=3)
+            # self.page.frame(name=login_frame).select_option("select#landingPageOptions", index=3)   #Trade Ticket
+            NextPageUrls=urls.trade_ticket()        
+        else:
+            raise Exception("version={} is not pre-defined".format(version))
+        
         # Fill username
         self.page.frame(name=login_frame).click("[placeholder=\"Login ID\"]")
         self.page.frame(name=login_frame).fill("[placeholder=\"Login ID\"]", username)
@@ -124,10 +135,16 @@ class SessionManager:
                 self.page.frame(name=login_frame).press("[placeholder=\"Password\"]", "Enter")
         except TimeoutError:
             raise Exception("Login was not successful; please check username and password")
-
+        
         # NOTE: THIS FUNCTIONALITY WILL SOON BE UNSUPPORTED/DEPRECATED.
-        if self.page.url != urls.trade_ticket():
+        
+        # if self.page.url != urls.trade_ticket():
+        if self.page.url != NextPageUrls:        
             # We need further authentication, so we'll send an SMS
+            ###############################################################################################
+            # print('[debug] not expected page {} but page {}'.format(urls.trade_ticket(),self.page.url))
+            #code below doesn't work once entered, no SMS in @cnMuggle case, 28Dec2023
+            ###############################################################################################
             print("Authentication state is not available. We will need to go through two factor authentication.")
             print("You should receive a code through SMS soon")
 
@@ -141,9 +158,11 @@ class SessionManager:
                 self.page.click("input:has-text(\"Continue\")")
             return False
 
-        self.page.wait_for_selector("#_txtSymbol")
+        if 'v2' in version:
+            self.page.wait_for_selector("#_txtSymbol")
 
         # Save our session
         self.save_and_close_session()
 
         return True
+


### PR DESCRIPTION
workaround of this issue, use version 0.2.3 or similar or call get_account_info_v2() in latest version like 0.3.5. Below change provides an alternative. **The major limitation is that by calling v1 or old API, the quote_v2() etc cannot be used.**

mainly modify the def **login()** in **schwab_api/authentication.py**
also add **example/example_legacy_v1.py** 

either use get_account_info_v2() or add version='v1'  as the login() parameter for get_account_info() to correctly return all schwab accounts info. For best backward compatibility , we should change the def login() default to 'version=v1' and explicit claim 'version=v2' for new API. I don't think I can make that decision and it will change the colab example as well.

example usage case
```
logged_in = api.login(
    username=username,
    password=password,
    totp_secret=totp_secret, # Get this using itsjafer.com/#/schwab.
    version='v1'   # or use 'old' 
)

# Get information about your accounts holdings
print("Getting account holdings information")
account_info = api.get_account_info()
```