### PR TITLE
Revert "Add settled fund to account information"

### DIFF
--- a/schwab_api/account_information.py
+++ b/schwab_api/account_information.py
@@ -1,12 +1,11 @@
 class Account(dict):
-    def __init__(self, account_id, positions, market_value, available_cash, account_value, cost_basis, settled_fund):
+    def __init__(self, account_id, positions, market_value, available_cash, account_value, cost_basis):
         self.account_id = account_id
         self.positions = positions
         self.market_value = market_value
         self.available_cash = available_cash
         self.account_value = account_value
         self.cost_basis = cost_basis
-        self.settled_fund = settled_fund
 
     def _as_dict(self):
         return {
@@ -16,7 +15,6 @@ class Account(dict):
             "available_cash": self.available_cash,
             "account_value": self.account_value,
             "cost_basis": self.cost_basis,
-            "settled_fund": self.settled_fund,
         }
 
     def __repr__(self) -> str:

--- a/schwab_api/schwab.py
+++ b/schwab_api/schwab.py
@@ -69,7 +69,6 @@ class Schwab(SessionManager):
                 account["Totals"]["CashInvestments"],
                 account["Totals"]["AccountValue"],
                 account["Totals"]["Cost"],
-                account["Totals"]["SettledFunds"],
             )._as_dict()
 
         return account_info


### PR DESCRIPTION
Reverts itsjafer/schwab-api#24

not compatible with get_account_info_v2

I have tried simply adding 'account["totals"]["SettledFunds"],' or 'account["totals"]["settledFunds"],' in schwab.py. 
Both doesn't work. 

Sorry, I am not good at web page side. So I really don't have the skill to find out what's the correct key word.

![image](https://github.com/itsjafer/schwab-api/assets/10713939/20862e85-c2cf-42fc-bf00-709171abffdc)
