### PR TITLE
Match v2 requests to website

### DIFF
--- a/schwab_api/schwab.py
+++ b/schwab_api/schwab.py
@@ -334,6 +334,8 @@ class Schwab(SessionManager):
 
     def update_token(self, token_type='api'):
         r = self.session.get(f"https://client.schwab.com/api/auth/authorize/scope/{token_type}")
+        if not r.ok:
+            raise ValueError("Error updating Bearer token: {r.reason}")
         token = json.loads(r.text)['token']
         self.headers['authorization'] = f"Bearer {token}"
 

--- a/schwab_api/schwab.py
+++ b/schwab_api/schwab.py
@@ -265,7 +265,6 @@ class Schwab(SessionManager):
         """
         quote_v2 takes a list of Tickers, and returns Quote information through the Schwab API.
         """
-        self.update_token()
         data = {
             "Symbols":tickers,
             "IsIra":False,

--- a/schwab_api/schwab.py
+++ b/schwab_api/schwab.py
@@ -1,5 +1,6 @@
 import json
 import urllib.parse
+import requests
 
 from . import urls
 from .account_information import Position, Account
@@ -217,7 +218,7 @@ class Schwab(SessionManager):
         # Adding this header seems to be necessary.
         self.headers['schwab-resource-version'] = '1.0'
 
-        r = self.session.post(urls.order_verification_v2(), json=data, headers=self.headers)
+        r = requests.post(urls.order_verification_v2(), json=data, headers=self.headers)
         if r.status_code != 200:
             return [r.text], False
 
@@ -244,7 +245,7 @@ class Schwab(SessionManager):
         data["OrderStrategy"]["OrderId"] = int(orderId)
         data["OrderProcessingControl"] = 2
         self.update_token(token_type='update')
-        r = self.session.post(urls.order_verification_v2(), json=data, headers=self.headers)
+        r = requests.post(urls.order_verification_v2(), json=data, headers=self.headers)
 
         if r.status_code != 200:
             return [r.text], False
@@ -275,7 +276,7 @@ class Schwab(SessionManager):
         self.headers['schwab-resource-version'] = '1.0'
 
         self.update_token(token_type='update')
-        r = self.session.post(urls.ticker_quotes_v2(), json=data, headers=self.headers)
+        r = requests.post(urls.ticker_quotes_v2(), json=data, headers=self.headers)
         if r.status_code != 200:
             return [r.text], False
 
@@ -293,7 +294,7 @@ class Schwab(SessionManager):
         self.headers['schwab-resource-version'] = '2.0'
         if account_id:
             self.headers["schwab-client-account"] = account_id
-        r = self.session.get(urls.orders_v2(), headers=self.headers)
+        r = requests.get(urls.orders_v2(), headers=self.headers)
         if r.status_code != 200:
             return [r.text], False
 
@@ -303,7 +304,7 @@ class Schwab(SessionManager):
     def get_account_info_v2(self):
         account_info = dict()
         self.update_token(token_type='api')
-        r = self.session.get(urls.positions_v2(), headers=self.headers)
+        r = requests.get(urls.positions_v2(), headers=self.headers)
         response = json.loads(r.text)
         for account in response['accounts']:
             positions = list()
@@ -332,8 +333,6 @@ class Schwab(SessionManager):
         return account_info
 
     def update_token(self, token_type='api'):
-        self.session.cookies.pop('ADRUM_BT1', None)
-        self.session.cookies.pop('ADRUM_BTa', None)
         r = self.session.get(f"https://client.schwab.com/api/auth/authorize/scope/{token_type}")
         token = json.loads(r.text)['token']
         self.headers['authorization'] = f"Bearer {token}"


### PR DESCRIPTION
When using a web browser, v2 requests (all the ausgateway.schwab.com urls) do not include cookies and use at least two different bearer tokens depending on the endpoint. This updates the v2 requests to match that.