### PR TITLE
Add API to fetch account transaction history

### DIFF
--- a/example/example.py
+++ b/example/example.py
@@ -28,7 +28,13 @@ pprint.pprint(quotes)
 print("Getting account holdings information")
 account_info = api.get_account_info_v2()
 pprint.pprint(account_info)
-print("The following account numbers were found: " + str(account_info.keys()))
+account_numbers = list(account_info.keys())
+print("The following account numbers were found: " + str(account_numbers))
+
+# Get transaction history for an account
+print("Getting full transaction history for account " + str(account_numbers[0]))
+transaction_history = api.get_transaction_history_v2(account_numbers[0])
+pprint.pprint(transaction_history)
 
 print("Placing a dry run trade for PFE stock")
 # Place a dry run trade for each account

--- a/schwab_api/schwab.py
+++ b/schwab_api/schwab.py
@@ -77,6 +77,44 @@ class Schwab(SessionManager):
 
         return account_info
 
+    def get_transaction_history_v2(self, account_id):
+        """
+            account_id (int) - The account ID to place the trade on. If the ID is XXXX-XXXX,
+                        we're looking for just XXXXXXXX.
+
+            Returns a dictionary of transaction history entries for the provided account ID.
+        """
+
+        data = {
+            "timeFrame": "All",
+            "selectedTransactionTypes": [
+                "Adjustments",
+                "AtmActivity",
+                "BillPay",
+                "CorporateActions",
+                "Checks",
+                "Deposits",
+                "DividendsAndCapitalGains",
+                "ElectronicTransfers",
+                "Fees",
+                "Interest",
+                "Misc",
+                "SecurityTransfers",
+                "Taxes",
+                "Trades",
+                "VisaDebitCard",
+                "Withdrawals"
+            ],
+            "exportType": "Json",
+            "selectedAccountId": str(account_id),
+            "sortColumn": "Date",
+            "sortDirection": "Descending"
+        }
+        r = requests.post(urls.transaction_history_v2(), json=data, headers=self.headers)
+        if r.status_code != 200:
+            return [r.text], False
+        return json.loads(r.text)
+
     def trade(self, ticker, side, qty, account_id, dry_run=True):
         """
             ticker (Str) - The symbol you want to trade,

--- a/schwab_api/urls.py
+++ b/schwab_api/urls.py
@@ -27,6 +27,9 @@ def orders_v2():
 def cancel_order_v2():
     return "https://ausgateway.schwab.com/api/is.TradeOrderStatusWeb/ITradeOrderStatusWeb/ITradeOrderStatusWebPort/orders/cancelorder"
 
+def transaction_history_v2():
+    return "https://ausgateway.schwab.com/api/is.TransactionHistoryWeb/TransactionHistoryInterface/TransactionHistory/brokerage/transactions/export"
+
 # Old API
 def positions_data():
     return "https://client.schwab.com/api/PositionV2/PositionsDataV2"


### PR DESCRIPTION
This PR introduces `schwab.get_transaction_history(account_id)`, which returns an object containing the full transaction history for the provided account ID.