### PR TITLE
increase default time out to 120s and append explanation for order_v2 buy fail

### DIFF
--- a/schwab_api/authentication.py
+++ b/schwab_api/authentication.py
@@ -93,7 +93,7 @@ class SessionManager:
         
         # Log in to schwab using Playwright
         with self.page.expect_navigation():
-            self.page.goto("https://www.schwab.com/")
+            self.page.goto("https://www.schwab.com/",timeout=120000)
 
 
         # Capture authorization token.

--- a/schwab_api/authentication.py
+++ b/schwab_api/authentication.py
@@ -93,7 +93,7 @@ class SessionManager:
         
         # Log in to schwab using Playwright
         with self.page.expect_navigation():
-            self.page.goto("https://www.schwab.com/",timeout=120000)
+            self.page.goto("https://www.schwab.com/", timeout=120000)
 
 
         # Capture authorization token.

--- a/schwab_api/schwab.py
+++ b/schwab_api/schwab.py
@@ -306,7 +306,7 @@ class Schwab(SessionManager):
             for message in response["orderStrategy"]["orderMessages"]:
                 messages.append(message["message"])
 
-        if response["orderStrategy"]["orderReturnCode"] in valid_return_codes:            
+        if response["orderStrategy"]["orderReturnCode"] in valid_return_codes:
             return messages, True
 
         return messages, False

--- a/schwab_api/schwab.py
+++ b/schwab_api/schwab.py
@@ -274,6 +274,7 @@ class Schwab(SessionManager):
             data["OrderStrategy"]["OrderLegs"][0]["Instrument"]["ItemIssueId"] = firstOrderLeg["schwabSecurityId"]
 
         messages = list()
+        messages.append('# dry_run message #')
         for message in response["orderStrategy"]["orderMessages"]:
             messages.append(message["message"])
 
@@ -298,12 +299,14 @@ class Schwab(SessionManager):
 
         response = json.loads(r.text)
 
-        messages = list()
+        # messages = list()        
+        messages.append('## place order message ##')
         if "orderMessages" in response["orderStrategy"] and response["orderStrategy"]["orderMessages"] is not None:
             for message in response["orderStrategy"]["orderMessages"]:
                 messages.append(message["message"])
 
         if response["orderStrategy"]["orderReturnCode"] in valid_return_codes:
+            messages.append('fail reason: orderReturnCode({}) is not valid_return_codes{}'.format(response["orderStrategy"]["orderReturnCode"], str(valid_return_codes)))
             return messages, True
 
         return messages, False

--- a/schwab_api/schwab.py
+++ b/schwab_api/schwab.py
@@ -280,6 +280,7 @@ class Schwab(SessionManager):
 
         # TODO: This needs to be fleshed out and clarified.
         if response["orderStrategy"]["orderReturnCode"] not in valid_return_codes:
+            messages.append('fail reason: orderReturnCode({}) is not valid_return_codes{}'.format(response["orderStrategy"]["orderReturnCode"], str(valid_return_codes)))
             return messages, False
 
         if dry_run:
@@ -305,8 +306,7 @@ class Schwab(SessionManager):
             for message in response["orderStrategy"]["orderMessages"]:
                 messages.append(message["message"])
 
-        if response["orderStrategy"]["orderReturnCode"] in valid_return_codes:
-            messages.append('fail reason: orderReturnCode({}) is not valid_return_codes{}'.format(response["orderStrategy"]["orderReturnCode"], str(valid_return_codes)))
+        if response["orderStrategy"]["orderReturnCode"] in valid_return_codes:            
             return messages, True
 
         return messages, False


### PR DESCRIPTION
1. solve time out error below
```
    logged_in = api_inst.login(
  File "../../git/schwab-api/schwab_api/authentication.py", line 171, in login
    self.page.goto("https://www.schwab.com/")
  File "../lib/python3.9/site-packages/playwright/sync_api/_generated.py", line 9312, in goto
    self._sync(
  File "../lib/python3.9/site-packages/playwright/_impl/_sync_base.py", line 115, in _sync
    return task.result()
  File "../lib/python3.9/site-packages/playwright/_impl/_page.py", line 475, in goto
    return await self._main_frame.goto(**locals_to_params(locals()))
  File "../lib/python3.9/site-packages/playwright/_impl/_frame.py", line 139, in goto
    await self._channel.send("goto", locals_to_params(locals()))
  File "../lib/python3.9/site-packages/playwright/_impl/_connection.py", line 62, in send
    return await self._connection.wrap_api_call(
  File "../lib/python3.9/site-packages/playwright/_impl/_connection.py", line 492, in wrap_api_call
    return await cb()
  File "../lib/python3.9/site-packages/playwright/_impl/_connection.py", line 100, in inner_send
    result = next(iter(done)).result()
playwright._impl._errors.TimeoutError: Timeout 30000ms exceeded.
```
2. the setup of default valid_return_codes ={0,10} may result in order_v2 buy fail but didn't tell why it failed (sell is successful and is not impacted). 

```
valid_return_codes (set) - Schwab returns an orderReturnCode in the response to both
                        the verification and execution requests, and it appears to be the
                        "severity" for the highest severity message.
                        Verification response messages with severity 10 include:
                            - The market is now closed. This order will be placed for the next
                              trading day
                            - You are purchasing an ETF...please read the prospectus
                            - It is your responsibility to choose the cost basis method
                              appropriate to your tax situation
                            - Quote at the time of order verification: $xx.xx
                        Verification response messages with severity 20 include at least:
                            - Insufficient settled funds (different from insufficient buying power)
                        Verification response messages with severity 25 include at least:
                            - This order is executable because the buy (or sell) limit is higher
                              (lower) than the ask (bid) price.
                        For the execution response, the orderReturnCode is typically 0 for a
                        successfully placed order.
                        Execution response messages with severity 30 include:
                            - Order Affirmation required (This means Schwab wants you to confirm
                              that you really meant to place this order as-is since something about
                              it meets Schwab's criteria for requiring verification. This is
                              usually analogous to a checkbox you would need to check when using
                              the web interface)
```

The issue can be resolved by forcing the below code in the screenshot
```
and dry_run
```
![image](https://github.com/itsjafer/schwab-api/assets/10713939/c1231683-2515-4f75-ae64-f84cd66fb6db)
but it's not desired. It's better to specify the type of valid_return_codes as example code below.
```
messages, success = api.trade_v2(    
                ticker="AAPL", 
                side='Buy', #or Sell
                qty=sharesNum, 
                account_id=account_id, # Replace with your account number
                dry_run=False, # If dry_run=True, we won't place the order, we'll just verify it.                
                valid_return_codes = {0,10,20}
                )
```

Before this code update, it's not obvious why this buy fail happened. So this fix add this message and also append the missing messages from dry_run to final order place.
