### PR TITLE
Allow session to be cached to disk

### DIFF
--- a/example/example.py
+++ b/example/example.py
@@ -10,7 +10,10 @@ password = os.getenv("SCHWAB_PASSWORD")
 totp_secret = os.getenv("SCHWAB_TOTP")
 
 # Initialize our schwab instance
-api = Schwab()
+api = Schwab(
+    # Optional session cache - uncomment to enable:
+    # session_cache="session.json"
+)
 
 # Login using playwright
 print("Logging into Schwab")
@@ -48,9 +51,9 @@ pprint.pprint(transaction_history)
 print("Placing a dry run trade for PFE stock")
 # Place a dry run trade for each account
 messages, success = api.trade_v2(
-    ticker="PFE", 
+    ticker="PFE",
     side="Buy", #or Sell
-    qty=1, 
+    qty=1,
     account_id=next(iter(account_info)), # Replace with your account number
     dry_run=True # If dry_run=True, we won't place the order, we'll just verify it.
 )

--- a/schwab_api/authentication.py
+++ b/schwab_api/authentication.py
@@ -16,7 +16,7 @@ USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:{version}) Gecko/2010
 VIEWPORT = { 'width': 1920, 'height': 1080 }
 
 class SessionManager:
-    def __init__(self) -> None:
+    def __init__(self, debug = False) -> None:
         """
         This class is using asynchronous playwright mode.
         """
@@ -25,6 +25,7 @@ class SessionManager:
         self.playwright = None
         self.browser = None
         self.page = None
+        self.debug = debug
 
         # cached credentials
         self.username = None
@@ -74,13 +75,14 @@ class SessionManager:
         if self._load_session_cache():
             # check hashed credentials
             if self.username_hash == username_hash and self.password_hash == password_hash and self.totp_secret_hash == totp_secret_hash:
-                print('hashed credentials okay')
+                if self.debug:
+                    print('hashed credentials okay')
                 try:
                     if self.update_token():
-                        print('session okay')
                         return True
                 except:
-                    print('update token failed')
+                    if self.debug:
+                        print('update token failed, falling back to login')
 
         # update hashed credentials
         self.username_hash = username_hash
@@ -95,7 +97,8 @@ class SessionManager:
         r = self.session.get(f"https://client.schwab.com/api/auth/authorize/scope/{token_type}")
         if not r.ok:
             if login:
-                print("session invalid; logging in again")
+                if self.debug:
+                    print("session invalid; logging in again")
                 result = asyncio.run(self._async_login())
                 return result
             else:

--- a/schwab_api/schwab.py
+++ b/schwab_api/schwab.py
@@ -8,19 +8,21 @@ from .account_information import Position, Account
 from .authentication import SessionManager
 
 class Schwab(SessionManager):
-    def __init__(self, **kwargs):
+    def __init__(self, session_cache=None, **kwargs):
         """
-            The Schwab class. Used to interact with schwab.
+        The Schwab class. Used to interact with the Schwab API.
 
+        :type session_cache: str
+        :param session_cache: Path to an optional session file, used to save/restore credentials
         """
         self.headless = kwargs.get("headless", True)
         self.browserType = kwargs.get("browserType", "firefox")
-        self.session_cache = kwargs.get("session_cache", None)
+        self.session_cache = session_cache
         super(Schwab, self).__init__()
 
     def get_account_info(self):
         """
-            Returns a dictionary of Account objects where the key is the account number
+        Returns a dictionary of Account objects where the key is the account number
         """
 
         account_info = dict()


### PR DESCRIPTION
Raising this as a draft, for some early feedback. This is just my first pass at doing this, and I feel that some of the error cases are not yet handled well enough.

A quick summary of the changes so far:
* Allows session cookies and headers to be cached to disk
* Attempts another login if call to `update_token` fails
* Session cache also stores hash for username, password, and TOTP secret, so that if any of the original unhashed values change, we know that the cached session cannot be used

Keen to hear what you think!