### PR TITLE
Remove redundant code

### DIFF
--- a/schwab_api/schwab.py
+++ b/schwab_api/schwab.py
@@ -219,7 +219,7 @@ class Schwab(SessionManager):
                         we're looking for just XXXXXXXX.
             order_type (int) - The order type. This is a Schwab-specific number, and there exists types
                         beyond 49 (Market) and 50 (Limit). This parameter allows setting specific types
-                        for those willing to trial-and-error. For reference but not tested: 
+                        for those willing to trial-and-error. For reference but not tested:
                         49 - Market
                         50 - Limit
                         51 - Stop market
@@ -288,7 +288,7 @@ class Schwab(SessionManager):
             raise Exception("side must be either Buy or Sell")
 
         # Handling formating of limit_price to avoid error.
-        # Checking how many decimal places are in limit_price. 
+        # Checking how many decimal places are in limit_price.
         decimal_places = len(str(float(limit_price)).split('.')[1])
         limit_price_warning = None
         # Max 2 decimal places allowed for price >= $1 and 4 decimal places for price < $1.
@@ -407,14 +407,14 @@ class Schwab(SessionManager):
             Use at own risk.
             Make sure you understand what you are doing when trading options and using this function.
             Option trading requires an application and approval process at Schwab.
-            
+
             strategy (int) - Type of options strategy:
                         2 leg strategies:
                         201 - vertical call spread
                         202 - vertical put spread
                         203 - calendar call spread (level 3)
                         204 - calendar put spread (level 3)
-                        205 - diagonal call spread 
+                        205 - diagonal call spread
                         206 - diagonal put spread
                         207 - ratio call spread (level 3)
                         208 - ratio put spread (level 3)
@@ -444,7 +444,7 @@ class Schwab(SessionManager):
                          49 - Market. Warning: Options are typically less liquid than stocks! limit orders strongly recommended!
                         201 - Net credit. To be used in conjuncture with limit price.
                         202 - Net debit. To be used in conjunture with limit price.
-            duration (int) - The duration type for the order. 
+            duration (int) - The duration type for the order.
                         48 - Day
                         49 - GTC Good till canceled
             limit_price (number) - The limit price to set with the order. Usage recommended.
@@ -568,8 +568,6 @@ class Schwab(SessionManager):
         response = json.loads(r.text)
 
         messages = list()
-        if limit_price_warning is not None:
-            messages.append(limit_price_warning)
         if "orderMessages" in response["orderStrategy"] and response["orderStrategy"]["orderMessages"] is not None:
             for message in response["orderStrategy"]["orderMessages"]:
                 messages.append(message["message"])
@@ -770,7 +768,7 @@ class Schwab(SessionManager):
              Please do not abuse this API call. It is pulling all the option chains for a ticker.
              It's not reverse engineered to the point where you can narrow it down to a range of strike prices and expiration dates.
              To look up an individual symbol's quote, prefer using quote_v2().
-        
+
              ticker (str) - ticker of the underlying security
              greeks (bool) - if greeks is true, you will also get the option greeks (Delta, Theta, Gamma etc... )
         """
@@ -778,7 +776,7 @@ class Schwab(SessionManager):
             "Symbol":ticker,
             "IncludeGreeks": "true" if greeks else "false"
         }
-        
+
         full_url= urllib.parse.urljoin(urls.option_chains_v2(), '?' + urllib.parse.urlencode(data))
 
         # Adding this header seems to be necessary.


### PR DESCRIPTION
It appears that `limit_price_warning` is never defined inside `option_trade_v2`, so these two lines are no longer required. I only noticed this because VSCode highlighted those lines with a warning.

I'm not familiar enough with the Schwab API to know whether a more correct solution would be to check the validity of the limit price, as in `trade_v2`. Happy to give that a go if you think that would be better.