### PR TITLE
Disable stealth options which block login iframe

### DIFF
--- a/schwab_api/authentication.py
+++ b/schwab_api/authentication.py
@@ -8,6 +8,7 @@ from . import urls
 import asyncio
 from playwright.async_api import async_playwright, TimeoutError
 from playwright_stealth import stealth_async
+from playwright_stealth.stealth import StealthConfig
 from requests.cookies import cookiejar_from_dict
 
 
@@ -135,7 +136,11 @@ class SessionManager:
             user_agent=user_agent,
             viewport=VIEWPORT
         )
-        await stealth_async(self.page)
+
+        config = StealthConfig()
+        config.navigator_languages = False
+        config.navigator_user_agent = False
+        await stealth_async(self.page, config)
 
         await self.page.goto("https://www.schwab.com/")
         await self.page.route(re.compile(r".*balancespositions*"), self._asyncCaptureAuthToken)

--- a/schwab_api/authentication.py
+++ b/schwab_api/authentication.py
@@ -140,6 +140,7 @@ class SessionManager:
         config = StealthConfig()
         config.navigator_languages = False
         config.navigator_user_agent = False
+        config.navigator_vendor = False
         await stealth_async(self.page, config)
 
         await self.page.goto("https://www.schwab.com/")


### PR DESCRIPTION
Fixes https://github.com/itsjafer/schwab-api/issues/63

On the main page, the iframe that was used for logging in was being blocked by the default stealth options. I went through each option and found the culprits and disabled them. This allows the iframe to show up while still keeping the other stealth options that allow logging in.

Would love a review, or if you have other thoughts, please let me know @itsjafer, but this fixes it for me.