### PR TITLE
updated positions_v2 url and parsing

### DIFF
--- a/schwab_api/schwab.py
+++ b/schwab_api/schwab.py
@@ -694,18 +694,18 @@ class Schwab(SessionManager):
             for security_group in account["groupedPositions"]:
                 if security_group["groupName"] == "Cash":
                     continue
-                for position in security_group["positions"]:
-                    if "symbol" not in position["symbolDetail"]:
+                for position in security_group["holdingsRows"]:
+                    if "symbol" not in position:
                         valid_parse = False
                         break
                     positions.append(
                         Position(
-                            position["symbolDetail"]["symbol"],
-                            position["symbolDetail"]["description"],
-                            float(position["quantity"]),
-                            0 if "costDetail" not in position else float(position["costDetail"]["costBasisDetail"]["costBasis"]),
-                            0 if "priceDetail" not in position else float(position["priceDetail"]["marketValue"]),
-                            position["symbolDetail"]["schwabSecurityId"]
+                            position["symbol"]["symbol"],
+                            position["description"],
+                            float(position["qty"]["qty"]),
+                            0 if "costBasis" not in position else float(position["costBasis"]["cstBasis"]),
+                            0 if "marketValue" not in position else float(position["marketValue"]["val"]),
+                            position["symbol"]["ssId"]
                         )._as_dict()
                     )
             if not valid_parse:

--- a/schwab_api/schwab.py
+++ b/schwab_api/schwab.py
@@ -686,6 +686,9 @@ class Schwab(SessionManager):
     def get_account_info_v2(self):
         account_info = dict()
         self.update_token(token_type='api')
+        # somewhere around 2025-08-25, this change became necessary
+        if 'schwab-client-account' in self.headers:
+            self.headers['Schwab-Client-Ids'] = self.headers['schwab-client-account']
         r = requests.get(urls.positions_v2(), headers=self.headers)
         response = json.loads(r.text)
         for account in response['accounts']:

--- a/schwab_api/urls.py
+++ b/schwab_api/urls.py
@@ -16,7 +16,7 @@ def account_info_v2():
     return "https://ausgateway.schwab.com/api/is.TradeOrderManagementWeb/v1/TradeOrderManagementWebPort/customer/accounts"
 
 def positions_v2():
-    return "https://ausgateway.schwab.com/api/is.Holdings/V1/Holdings/Holdings?=&includeCostBasis=true&includeRatings=true&includeUnderlyingOption=true"
+    return "https://ausgateway.schwab.com/api/is.Holdings/V1/Holdings/HoldingV2"
 
 def ticker_quotes_v2():
     return "https://ausgateway.schwab.com/api/is.TradeOrderManagementWeb/v1/TradeOrderManagementWebPort/market/quotes/list"


### PR DESCRIPTION
sometime around May 22, 2025, the existing positions_v2 url stopped working

I went into developer tools in my schwab account to find this endpoint and then looked at its return json. It's a different data structure, so I updated that code as well. I could only test with the positions in my account (ETFs) so I don't know if this is full enough of an implementation.